### PR TITLE
🍎 Fix fruit scoring

### DIFF
--- a/src/backend/utilities/Items/Fruit.js
+++ b/src/backend/utilities/Items/Fruit.js
@@ -1,3 +1,4 @@
+import Ghost from '../Players/Ghost.js';
 import Item from './Item.js';
 
 export default class Fruit extends Item {
@@ -11,6 +12,12 @@ export default class Fruit extends Item {
   }
 
   use(player) {
+    if (player instanceof Ghost) {
+      this.points = 2 * this.points;
+      if (player.isScared) {
+        this.points = 2 * this.points;
+      }
+    }
     player.incrementScore(this.points);
     return true;
   }

--- a/src/backend/utilities/Items/Fruit.js
+++ b/src/backend/utilities/Items/Fruit.js
@@ -10,7 +10,8 @@ export default class Fruit extends Item {
     });
   }
 
-  use() {
+  use(player) {
+    player.incrementScore(this.points);
     return true;
   }
 }

--- a/src/backend/utilities/Players/Ghost.js
+++ b/src/backend/utilities/Players/Ghost.js
@@ -2,6 +2,7 @@ import Player from './Player.js';
 import PacMan from './PacMan.js';
 
 const CHANCE_RUN_FROM_POWERED_PACMAN = 0.9;
+const CHANCE_TO_EAT_FRUIT = 0.5;
 const MAX_SECONDS_CHASE_MODE = 20;
 const MAX_SECONDS_SCATTER_MODE = 9;
 const MIN_SECONDS_PER_TRAVEL_MODE = 3;
@@ -59,6 +60,11 @@ export default class Ghost extends Player {
       const chosenPath = lairPaths[Math.floor(Math.random() * lairPaths.length)];
       
       return Math.random() < 0.5 ? chosenPath.start.position : chosenPath.end.position;
+    }
+
+    const fruit = game.items.find((item) => item.type === 'fruit');
+    if (fruit && Math.random() < CHANCE_TO_EAT_FRUIT) {
+      return fruit.position;
     }
 
     const pacman = game.players.find((player) => player instanceof PacMan);

--- a/test/backend/utilities/Items/Fruit.test.js
+++ b/test/backend/utilities/Items/Fruit.test.js
@@ -1,4 +1,5 @@
 import { Fruit } from '@/backend/utilities/Items';
+import { PacMan, Ghost, Player } from '@/backend/utilities/Players';
 import Chance from 'chance';
 
 const chance = new Chance();
@@ -25,10 +26,48 @@ describe('Fruit', () => {
   });
 
   describe('use()', () => {
-
+    let player, initalPointsValue;
+    
     it('returns truthy', () => {
-      const response = fruit.use();
+      const response = fruit.use(new Player());
       expect(response).toBeTruthy();
+    });
+
+    describe('given the player is PacMan', () => {
+      beforeEach(() => {
+        initalPointsValue = fruit.points;
+        player = new PacMan();
+        fruit.use(player);
+      });
+      
+      it('increments the player score', () => {
+        expect(player.score).toEqual(fruit.points);
+      });
+    });
+
+    describe('given the player is a Ghost', () => {
+      beforeEach(() => {
+        initalPointsValue = fruit.points;
+        player = new Ghost();
+      });
+
+      it('doubles the point value and increments the players score', () => {
+        fruit.use(player);
+        expect(fruit.points).toEqual(initalPointsValue * 2);
+        expect(player.score).toEqual(fruit.points);
+      });
+
+      describe('given the player is scared', () => {
+        beforeEach(() => {
+          player.isScared = true;
+        });
+        
+        it('quadruples the point value and increments the players score', () => {
+          fruit.use(player);
+          expect(fruit.points).toEqual(initalPointsValue * 4);
+          expect(player.score).toEqual(fruit.points);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
- Fix fruits not incrementing player score
- Have ghosts earn more points from fruits
- Have ghosts earn even more points from fruits while scared of Pac-Man
- Allow CPU ghosts to target fruits